### PR TITLE
🔧 chore: add STL support

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -21,7 +21,7 @@ set (OcctToolkits
     # ApplicationFramework
     TKCDF TKLCAF TKCAF TKStdL TKStd TKVCAF TKBin TKBinL TKBinXCAF
     # DataExchange
-    TKDE TKXSBase TKXCAF TKDESTEP TKDEIGES
+    TKDE TKXSBase TKXCAF TKDESTEP TKDEIGES TKDESTL
 )
 
 set (OcctUsedPackages)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "chili3d",
-    "version": "0.6-beta",
+    "version": "0.6.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "chili3d",
-            "version": "0.6-beta",
+            "version": "0.6.0",
             "workspaces": [
                 "packages/*"
             ],
@@ -9320,7 +9320,7 @@
             }
         },
         "packages/chili": {
-            "version": "0.5",
+            "version": "0.6.0",
             "devDependencies": {
                 "chili-core": "*",
                 "chili-geo": "*",
@@ -9328,7 +9328,7 @@
             }
         },
         "packages/chili-builder": {
-            "version": "0.5",
+            "version": "0.6.0",
             "devDependencies": {
                 "chili": "*",
                 "chili-three": "*",
@@ -9337,17 +9337,17 @@
             }
         },
         "packages/chili-controls": {
-            "version": "0.6-beta",
+            "version": "0.6.0",
             "devDependencies": {
                 "chili-core": "*"
             }
         },
         "packages/chili-core": {
-            "version": "0.5",
+            "version": "0.6.0",
             "devDependencies": {}
         },
         "packages/chili-geo": {
-            "version": "0.5",
+            "version": "0.6.0",
             "devDependencies": {
                 "chili-core": "*"
             }
@@ -9366,13 +9366,13 @@
             "devDependencies": {}
         },
         "packages/chili-storage": {
-            "version": "0.5",
+            "version": "0.6.0",
             "devDependencies": {
                 "chili-core": "*"
             }
         },
         "packages/chili-three": {
-            "version": "0.5",
+            "version": "0.6.0",
             "devDependencies": {
                 "@types/three": "0.175.0",
                 "chili-core": "*",
@@ -9382,27 +9382,28 @@
             }
         },
         "packages/chili-ui": {
-            "version": "0.5",
+            "version": "0.6.0",
             "devDependencies": {
+                "chili-controls": "*",
                 "chili-core": "*",
                 "chili-geo": "*",
                 "chili-vis": "*"
             }
         },
         "packages/chili-vis": {
-            "version": "0.5",
+            "version": "0.6.0",
             "devDependencies": {
                 "chili-core": "*"
             }
         },
         "packages/chili-wasm": {
-            "version": "0.5",
+            "version": "0.6.0",
             "devDependencies": {
                 "chili-core": "*"
             }
         },
         "packages/chili-web": {
-            "version": "0.5",
+            "version": "0.6.0",
             "devDependencies": {
                 "chili-builder": "*"
             }
@@ -11620,6 +11621,7 @@
         "chili-ui": {
             "version": "file:packages/chili-ui",
             "requires": {
+                "chili-controls": "*",
                 "chili-core": "*",
                 "chili-geo": "*",
                 "chili-vis": "*"

--- a/packages/chili-controls/src/converters/colorConverter.ts
+++ b/packages/chili-controls/src/converters/colorConverter.ts
@@ -5,7 +5,30 @@ import { IConverter, Result } from "chili-core";
 
 export class ColorConverter implements IConverter<number | string> {
     convert(value: number | string): Result<string> {
-        return Result.ok(typeof value === "string" ? value : `#${value.toString(16).padStart(6, "0")}`);
+        // Handle undefined, null, or invalid values
+        if (value === undefined || value === null) {
+            return Result.ok("#808080"); // Default gray color
+        }
+
+        if (typeof value === "string") {
+            // If it's already a valid hex string, return it
+            if (value.startsWith("#") && /^#[0-9A-Fa-f]{6}$/.test(value)) {
+                return Result.ok(value);
+            }
+            // If it's a hex string without #, add it
+            if (/^[0-9A-Fa-f]{6}$/.test(value)) {
+                return Result.ok(`#${value}`);
+            }
+            // If it's an empty string or invalid, use default
+            return Result.ok("#808080");
+        }
+
+        if (typeof value === "number" && !isNaN(value)) {
+            return Result.ok(`#${value.toString(16).padStart(6, "0")}`);
+        }
+
+        // Fallback for any other invalid values
+        return Result.ok("#808080");
     }
 
     convertBack(value: string): Result<number> {

--- a/packages/chili-controls/test/converter.test.ts
+++ b/packages/chili-controls/test/converter.test.ts
@@ -2,9 +2,10 @@
 // See LICENSE file in the project root for full license information.
 
 import { IConverter, XYZ } from "chili-core";
-import { XYZConverter } from "../src/converters/xyzConverter";
+import { ColorConverter } from "../src/converters/colorConverter";
 import { NumberConverter } from "../src/converters/numberConverter";
 import { StringConverter } from "../src/converters/stringConverter";
+import { XYZConverter } from "../src/converters/xyzConverter";
 
 describe("converter test", () => {
     test("test type", () => {
@@ -39,5 +40,31 @@ describe("converter test", () => {
         let converter = new StringConverter();
         expect(converter.convert("").value).toBe("");
         expect(converter.convertBack("").value).toBe("");
+    });
+
+    test("test ColorConverter", () => {
+        let converter = new ColorConverter();
+
+        // Test normal number conversion
+        expect(converter.convert(0xff0000).value).toBe("#ff0000");
+        expect(converter.convert(255).value).toBe("#0000ff");
+        expect(converter.convert(0).value).toBe("#000000");
+
+        // Test string conversion
+        expect(converter.convert("#ff0000").value).toBe("#ff0000");
+        expect(converter.convert("ff0000").value).toBe("#ff0000");
+        expect(converter.convert("#FF0000").value).toBe("#FF0000");
+
+        // Test undefined and null handling (NEW)
+        expect(converter.convert(undefined as any).value).toBe("#808080");
+        expect(converter.convert(null as any).value).toBe("#808080");
+        expect(converter.convert("" as any).value).toBe("#808080");
+        expect(converter.convert("invalid" as any).value).toBe("#808080");
+        expect(converter.convert(NaN as any).value).toBe("#808080");
+
+        // Test convertBack
+        expect(converter.convertBack("#ff0000").value).toBe(0xff0000);
+        expect(converter.convertBack("ff0000").value).toBe(0xff0000);
+        expect(converter.convertBack("invalid").isOk).toBe(false);
     });
 });

--- a/packages/chili-core/src/shape/shapeConverter.ts
+++ b/packages/chili-core/src/shape/shapeConverter.ts
@@ -13,4 +13,6 @@ export interface IShapeConverter {
     convertFromSTEP(document: IDocument, step: Uint8Array): Result<FolderNode>;
     convertToBrep(shape: IShape): Result<string>;
     convertFromBrep(brep: string): Result<IShape>;
+    convertToSTL(...shapes: IShape[]): Result<string>;
+    convertFromSTL(document: IDocument, stl: Uint8Array): Result<FolderNode>;
 }

--- a/packages/chili-wasm/lib/chili-wasm.d.ts
+++ b/packages/chili-wasm/lib/chili-wasm.d.ts
@@ -579,8 +579,10 @@ interface EmbindModule {
         convertFromBrep(_0: EmbindString): TopoDS_Shape;
         convertFromStep(_0: Uint8Array): ShapeNode | undefined;
         convertFromIges(_0: Uint8Array): ShapeNode | undefined;
+        convertFromStl(_0: Uint8Array): ShapeNode | undefined;
         convertToStep(_0: Array<TopoDS_Shape>): string;
         convertToIges(_0: Array<TopoDS_Shape>): string;
+        convertToStl(_0: Array<TopoDS_Shape>): string;
     };
     ShapeResult: {};
     ShapeFactory: {


### PR DESCRIPTION
- Updated package-lock.json to version 0.6.0 across multiple packages.
- Enhanced CMakeLists.txt to include TKDESTL toolkit.
- Implemented STL import/export functionality in converter.cpp and defaultDataExchange.ts.
- Added methods for STL conversion in shapeConverter.ts and OccShapeConverter.
- Updated TypeScript definitions for new STL methods in chili-wasm.d.ts.
![image](https://github.com/user-attachments/assets/3429ec34-4230-4ea9-a904-929faa7d71ad)
![20250615_141437](https://github.com/user-attachments/assets/5860af88-abcf-4c5c-8b53-9fc9a7b16e3a)
