### PR TITLE
fix(ui): ensure toolbar content categories are not hidden by scrollbar in Firefox

### DIFF
--- a/packages/chili-ui/src/ribbon/ribbon.module.css
+++ b/packages/chili-ui/src/ribbon/ribbon.module.css
@@ -225,15 +225,8 @@
     background-color: var(--panel-background-color);
     border-bottom: 1px solid var(--border-color);
     overflow-x: auto;
-
-    &::-webkit-scrollbar {
-        height: 6px;
-    }
-
-    &::-webkit-scrollbar-thumb {
-        background: #888;
-        border-radius: 5px;
-    }
+    scrollbar-gutter: stable;
+    padding-bottom: 16px;
 
     & .groupPanel {
         display: flex;


### PR DESCRIPTION
Removed custom webkit scrollbar styling and added bottom padding to the scrollable area. This prevents content from being covered by overlay scrollbars in Firefox, at the cost of extra space in Chrome.
Fixes issue #89