### PR TITLE
refactor: command context panel

### DIFF
--- a/packages/chili-ui/src/CommandContextPanel.ts
+++ b/packages/chili-ui/src/CommandContextPanel.ts
@@ -4,8 +4,11 @@ import { CommandContext } from "./ribbon/commandContext";
 import style from "./ribbon/ribbon.module.css";
 
 export class CommandContextPanel extends HTMLElement {
-    private readonly _panel = div({ className: style.commandContextPanel });
+    private readonly _panel = div({
+        className: style.commandContextOverlay + " " + style.commandContextOverlayHidden,
+    });
     private commandContext?: CommandContext;
+    private _visible = false;
 
     constructor() {
         super();
@@ -28,6 +31,7 @@ export class CommandContextPanel extends HTMLElement {
         }
         this.commandContext = new CommandContext(command);
         this._panel.append(this.commandContext);
+        this.setVisible(true);
     };
 
     private readonly closeContext = () => {
@@ -35,7 +39,17 @@ export class CommandContextPanel extends HTMLElement {
         this.commandContext?.dispose();
         this.commandContext = undefined;
         this._panel.innerHTML = "";
+        this.setVisible(false);
     };
+
+    private setVisible(visible: boolean) {
+        this._visible = visible;
+        if (visible) {
+            this._panel.className = style.commandContextOverlay;
+        } else {
+            this._panel.className = style.commandContextOverlay + " " + style.commandContextOverlayHidden;
+        }
+    }
 }
 
 customElements.define("command-context-panel", CommandContextPanel);

--- a/packages/chili-ui/src/CommandContextPanel.ts
+++ b/packages/chili-ui/src/CommandContextPanel.ts
@@ -1,0 +1,41 @@
+import { div } from "chili-controls";
+import { ICommand, PubSub } from "chili-core";
+import { CommandContext } from "./ribbon/commandContext";
+import style from "./ribbon/ribbon.module.css";
+
+export class CommandContextPanel extends HTMLElement {
+    private readonly _panel = div({ className: style.commandContextPanel });
+    private commandContext?: CommandContext;
+
+    constructor() {
+        super();
+        this.append(this._panel);
+    }
+
+    connectedCallback(): void {
+        PubSub.default.sub("openCommandContext", this.openContext);
+        PubSub.default.sub("closeCommandContext", this.closeContext);
+    }
+
+    disconnectedCallback(): void {
+        PubSub.default.remove("openCommandContext", this.openContext);
+        PubSub.default.remove("closeCommandContext", this.closeContext);
+    }
+
+    private readonly openContext = (command: ICommand) => {
+        if (this.commandContext) {
+            this.closeContext();
+        }
+        this.commandContext = new CommandContext(command);
+        this._panel.append(this.commandContext);
+    };
+
+    private readonly closeContext = () => {
+        this.commandContext?.remove();
+        this.commandContext?.dispose();
+        this.commandContext = undefined;
+        this._panel.innerHTML = "";
+    };
+}
+
+customElements.define("command-context-panel", CommandContextPanel);

--- a/packages/chili-ui/src/editor.module.css
+++ b/packages/chili-ui/src/editor.module.css
@@ -35,9 +35,13 @@
         background-color: var(--viewport-background-color);
         flex: 1 1 auto;
         width: 0;
+        min-height: 0;
+        display: flex;
+        flex-direction: column;
 
         .viewport {
-            height: 100%;
+            flex: 1 1 auto;
+            min-height: 0;
             position: relative;
         }
     }

--- a/packages/chili-ui/src/editor.ts
+++ b/packages/chili-ui/src/editor.ts
@@ -13,6 +13,7 @@ import {
     PubSub,
     RibbonTab,
 } from "chili-core";
+import { CommandContextPanel } from "./CommandContextPanel";
 import style from "./editor.module.css";
 import { OKCancel } from "./okCancel";
 import { ProjectView } from "./project";
@@ -41,6 +42,7 @@ export class Editor extends HTMLElement {
         this._selectionController = new OKCancel();
         this._viewportContainer = div(
             { className: style.viewportContainer },
+            new CommandContextPanel(),
             this._selectionController,
             viewport,
         );

--- a/packages/chili-ui/src/ribbon/commandContext.module.css
+++ b/packages/chili-ui/src/ribbon/commandContext.module.css
@@ -5,6 +5,9 @@
     align-items: center;
     margin: 2px 8px;
     gap: 12px;
+    text-wrap: nowrap;
+    overflow: hidden;
+    overflow-x: auto;
 }
 
 .title {

--- a/packages/chili-ui/src/ribbon/ribbon.module.css
+++ b/packages/chili-ui/src/ribbon/ribbon.module.css
@@ -251,6 +251,30 @@
     border-bottom: 1px solid var(--border-color);
 }
 
+.commandContextOverlay {
+    position: absolute;
+    top: 0px;
+    left: 50%;
+    transform: translateX(-50%);
+    max-width: 600px;
+    min-width: 320px;
+    width: 60%;
+    z-index: 10;
+    background: var(--panel-background-color);
+    /* Subtle, soft shadow only on bottom and sides */
+    box-shadow:
+        0 6px 24px -6px rgba(0, 0, 0, 0.1),
+        0 2px 8px -2px rgba(0, 0, 0, 0.08);
+    border-radius: 0 0 12px 12px;
+    opacity: 1;
+    transition: opacity 0.2s;
+    pointer-events: auto;
+}
+.commandContextOverlayHidden {
+    opacity: 0;
+    pointer-events: none;
+}
+
 .ribbonGroup {
     position: relative;
     display: grid;

--- a/packages/chili-ui/src/ribbon/ribbon.module.css
+++ b/packages/chili-ui/src/ribbon/ribbon.module.css
@@ -223,7 +223,6 @@
     display: flex;
     flex-direction: row;
     background-color: var(--panel-background-color);
-    border-bottom: 1px solid var(--border-color);
     overflow-x: auto;
 
     &::-webkit-scrollbar {
@@ -238,34 +237,29 @@
     & .groupPanel {
         display: flex;
         flex-direction: row;
+        padding: 2px;
     }
 }
 
-.commandContextPanel {
-    display: flex;
-    flex-direction: row;
-    justify-content: stretch;
-    flex: 1 1 auto;
-    height: 32px;
-    background-color: var(--panel-background-color);
-    border-bottom: 1px solid var(--border-color);
-}
-
 .commandContextOverlay {
+    display: flex;
     position: absolute;
     top: 0px;
     left: 50%;
     transform: translateX(-50%);
-    max-width: 600px;
+    max-width: 90%;
     min-width: 320px;
-    width: 60%;
+    height: 32px;
+    padding: 4px;
+    width: fit-content;
     z-index: 10;
     background: var(--panel-background-color);
     /* Subtle, soft shadow only on bottom and sides */
     box-shadow:
         0 6px 24px -6px rgba(0, 0, 0, 0.1),
         0 2px 8px -2px rgba(0, 0, 0, 0.08);
-    border-radius: 0 0 12px 12px;
+    border-radius: 10px;
+    border: 1px solid var(--border-color);
     opacity: 1;
     transition: opacity 0.2s;
     pointer-events: auto;

--- a/packages/chili-ui/src/ribbon/ribbon.ts
+++ b/packages/chili-ui/src/ribbon/ribbon.ts
@@ -19,7 +19,6 @@ import {
     PubSub,
     Result,
 } from "chili-core";
-import { CommandContext } from "./commandContext";
 import style from "./ribbon.module.css";
 import { RibbonButton } from "./ribbonButton";
 import { RibbonCommandData, RibbonGroupData, RibbonTabData } from "./ribbonData";
@@ -105,13 +104,10 @@ class DisplayConverter implements IConverter<RibbonTabData> {
 }
 
 export class Ribbon extends HTMLElement {
-    private readonly _commandContext = div({ className: style.commandContextPanel });
-    private commandContext?: CommandContext;
-
     constructor(readonly dataContent: RibbonDataContent) {
         super();
         this.className = style.root;
-        this.append(this.header(), this.ribbonTabs(), this._commandContext);
+        this.append(this.header(), this.ribbonTabs());
     }
 
     private header() {
@@ -254,31 +250,6 @@ export class Ribbon extends HTMLElement {
             return new RibbonButton(item.display, item.icon, ButtonSize.large, item.onClick);
         }
     }
-
-    connectedCallback(): void {
-        PubSub.default.sub("openCommandContext", this.openContext);
-        PubSub.default.sub("closeCommandContext", this.closeContext);
-    }
-
-    disconnectedCallback(): void {
-        PubSub.default.remove("openCommandContext", this.openContext);
-        PubSub.default.remove("closeCommandContext", this.closeContext);
-    }
-
-    private readonly openContext = (command: ICommand) => {
-        if (this.commandContext) {
-            this.closeContext();
-        }
-        this.commandContext = new CommandContext(command);
-        this._commandContext.append(this.commandContext);
-    };
-
-    private readonly closeContext = () => {
-        this.commandContext?.remove();
-        this.commandContext?.dispose();
-        this.commandContext = undefined;
-        this._commandContext.innerHTML = "";
-    };
 }
 
 customElements.define("chili-ribbon", Ribbon);


### PR DESCRIPTION
Move the command context panel logic into its own file.
Move the location of it in the UI to take up less screen real estate by moving it to be the same width as the viewport.