### PR TITLE
feat(ui): make sidebar resizable with flexible min and max width

### DIFF
--- a/packages/chili-ui/src/editor.module.css
+++ b/packages/chili-ui/src/editor.module.css
@@ -17,9 +17,12 @@
     & .sidebar {
         display: flex;
         flex-direction: column;
-        flex: 0 0 360px;
-        max-width: 400px;
+        /* Remove fixed flex-basis, allow inline style for width */
+        /* flex: 0 0 360px; */
+        min-width: 150px;
+        max-width: 85%;
         background-color: var(--background-color);
+        position: relative;
 
         & .sidebarItem {
             margin-top: 10px;
@@ -40,6 +43,21 @@
             position: relative;
         }
     }
+}
+
+.sidebarResizer {
+    width: 6px;
+    cursor: ew-resize;
+    position: absolute;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    z-index: 10;
+    background: linear-gradient(to right, rgba(0, 0, 0, 0.04), rgba(0, 0, 0, 0.12));
+    transition: background 0.2s;
+}
+.sidebarResizer:hover {
+    background: linear-gradient(to right, rgba(0, 0, 0, 0.12), rgba(0, 0, 0, 0.18));
 }
 
 .statusbar {

--- a/packages/chili-ui/src/editor.ts
+++ b/packages/chili-ui/src/editor.ts
@@ -2,23 +2,36 @@
 // See LICENSE file in the project root for full license information.
 
 import { div } from "chili-controls";
-import { AsyncController, Button, CommandKeys, I18nKeys, IApplication, IDocument, Material, PubSub, RibbonTab } from "chili-core";
+import {
+    AsyncController,
+    Button,
+    CommandKeys,
+    I18nKeys,
+    IApplication,
+    IDocument,
+    Material,
+    PubSub,
+    RibbonTab,
+} from "chili-core";
 import style from "./editor.module.css";
+import { OKCancel } from "./okCancel";
 import { ProjectView } from "./project";
 import { PropertyView } from "./property";
+import { MaterialDataContent, MaterialEditor } from "./property/material";
 import { Ribbon, RibbonDataContent } from "./ribbon";
 import { RibbonTabData } from "./ribbon/ribbonData";
 import { Statusbar } from "./statusbar";
 import { LayoutViewport } from "./viewport";
-import { MaterialDataContent, MaterialEditor } from "./property/material";
-import { OKCancel } from "./okCancel";
 
 let quickCommands: CommandKeys[] = ["doc.save", "doc.saveToFile", "edit.undo", "edit.redo"];
 
 export class Editor extends HTMLElement {
     readonly ribbonContent: RibbonDataContent;
     private readonly _selectionController: OKCancel;
-    private readonly _viewportContainer: HTMLDivElement
+    private readonly _viewportContainer: HTMLDivElement;
+    private _sidebarWidth: number = 360;
+    private _isResizingSidebar: boolean = false;
+    private _sidebarEl: HTMLDivElement | null = null;
 
     constructor(app: IApplication, tabs: RibbonTab[]) {
         super();
@@ -29,38 +42,69 @@ export class Editor extends HTMLElement {
         this._viewportContainer = div(
             { className: style.viewportContainer },
             this._selectionController,
-            viewport
-        )
+            viewport,
+        );
         this.clearSelectionControl();
         this.render();
         document.body.appendChild(this);
     }
 
     private render() {
+        // Sidebar element with resizer
+        const sidebar = div(
+            {
+                className: style.sidebar,
+                style: `width: ${this._sidebarWidth}px;`,
+            },
+            new ProjectView({ className: style.sidebarItem }),
+            new PropertyView({ className: style.sidebarItem }),
+            div({
+                className: style.sidebarResizer,
+                onmousedown: (e: MouseEvent) => this._startSidebarResize(e),
+            }),
+        ) as HTMLDivElement;
+        this._sidebarEl = sidebar;
         this.append(
             div(
                 { className: style.root },
                 new Ribbon(this.ribbonContent),
-                div(
-                    { className: style.content },
-                    div(
-                        { className: style.sidebar },
-                        new ProjectView({ className: style.sidebarItem }),
-                        new PropertyView({ className: style.sidebarItem }),
-                    ),
-                    this._viewportContainer
-                ),
+                div({ className: style.content }, sidebar, this._viewportContainer),
                 new Statusbar(style.statusbar),
             ),
         );
     }
 
+    private _startSidebarResize(e: MouseEvent) {
+        e.preventDefault();
+        this._isResizingSidebar = true;
+        document.body.style.cursor = "ew-resize";
+        const onMouseMove = (ev: MouseEvent) => {
+            if (!this._isResizingSidebar) return;
+            if (!this._sidebarEl) return;
+            const sidebarRect = this._sidebarEl.getBoundingClientRect();
+            let newWidth = ev.clientX - sidebarRect.left;
+            const minWidth = 75;
+            const maxWidth = Math.floor(window.innerWidth * 0.85);
+            newWidth = Math.max(minWidth, Math.min(maxWidth, newWidth));
+            this._sidebarWidth = newWidth;
+            this._sidebarEl.style.width = `${newWidth}px`;
+        };
+        const onMouseUp = () => {
+            this._isResizingSidebar = false;
+            document.body.style.cursor = "";
+            window.removeEventListener("mousemove", onMouseMove);
+            window.removeEventListener("mouseup", onMouseUp);
+        };
+        window.addEventListener("mousemove", onMouseMove);
+        window.addEventListener("mouseup", onMouseUp);
+    }
+
     connectedCallback(): void {
-            PubSub.default.sub("showSelectionControl", this.showSelectionControl);
-            PubSub.default.sub("editMaterial", this._handleMaterialEdit);
-            PubSub.default.sub("clearSelectionControl", this.clearSelectionControl);
-        }
-    
+        PubSub.default.sub("showSelectionControl", this.showSelectionControl);
+        PubSub.default.sub("editMaterial", this._handleMaterialEdit);
+        PubSub.default.sub("clearSelectionControl", this.clearSelectionControl);
+    }
+
     disconnectedCallback(): void {
         PubSub.default.remove("showSelectionControl", this.showSelectionControl);
         PubSub.default.remove("editMaterial", this._handleMaterialEdit);


### PR DESCRIPTION
- Sidebar can now be resized as small as 75px and up to 85% of the window width
- Improves usability for users who want more or less space for the sidebar or viewport
- Resizer bar added for intuitive drag-to-resize interaction