### PR TITLE
feat(ui): add tooltips to viewport control buttons

### DIFF
--- a/packages/chili-core/src/i18n/en.ts
+++ b/packages/chili-core/src/i18n/en.ts
@@ -246,5 +246,10 @@ export default {
         "transform.scale": "Scale",
         "transform.translation": "Translation",
         "vertex.point": "Point",
+        "viewport.orthographic": "Orthographic",
+        "viewport.perspective": "Perspective",
+        "viewport.fitContent": "Fit Content",
+        "viewport.zoomIn": "Zoom In",
+        "viewport.zoomOut": "Zoom Out",
     },
 } satisfies Locale;

--- a/packages/chili-core/src/i18n/keys.ts
+++ b/packages/chili-core/src/i18n/keys.ts
@@ -240,6 +240,11 @@ const I18N_KEYS = [
     "transform.scale",
     "transform.translation",
     "vertex.point",
+    "viewport.orthographic",
+    "viewport.perspective",
+    "viewport.fitContent",
+    "viewport.zoomIn",
+    "viewport.zoomOut",
 ] as const;
 
 export type I18nKeys = (typeof I18N_KEYS)[number];

--- a/packages/chili-core/src/i18n/zh-cn.ts
+++ b/packages/chili-core/src/i18n/zh-cn.ts
@@ -245,5 +245,10 @@ export default {
         "transform.scale": "缩放",
         "transform.translation": "位移",
         "vertex.point": "点",
+        "viewport.orthographic": "正交视图",
+        "viewport.perspective": "透视视图",
+        "viewport.fitContent": "适应内容",
+        "viewport.zoomIn": "放大",
+        "viewport.zoomOut": "缩小",
     },
 } satisfies Locale;

--- a/packages/chili-ui/src/viewport/viewport.ts
+++ b/packages/chili-ui/src/viewport/viewport.ts
@@ -32,7 +32,10 @@ export class Viewport extends HTMLElement {
     private readonly _eventCaches: [keyof HTMLElementEventMap, (e: any) => void][] = [];
     private readonly _acts: HTMLElement;
 
-    constructor(readonly view: IView, readonly showViewControls: boolean) {
+    constructor(
+        readonly view: IView,
+        readonly showViewControls: boolean,
+    ) {
         super();
         this.className = style.root;
         this._flyout = new Flyout();
@@ -52,15 +55,17 @@ export class Viewport extends HTMLElement {
     private render() {
         this.append(
             this._acts,
-            this.showViewControls ? div(
-                {
-                    className: style.viewControls,
-                    onpointerdown: (ev) => ev.stopPropagation(),
-                    onclick: (e) => e.stopPropagation(),
-                },
-                this.createCameraControls(),
-                this.createActionControls(),
-            ) : "",
+            this.showViewControls
+                ? div(
+                      {
+                          className: style.viewControls,
+                          onpointerdown: (ev) => ev.stopPropagation(),
+                          onclick: (e) => e.stopPropagation(),
+                      },
+                      this.createCameraControls(),
+                      this.createActionControls(),
+                  )
+                : "",
         );
     }
 
@@ -77,6 +82,7 @@ export class Viewport extends HTMLElement {
             { className: style.border },
             svg({
                 icon: "icon-fitcontent",
+                title: new Localize("viewport.fitContent"),
                 onclick: async (e) => {
                     e.stopPropagation();
                     this.view.cameraController.fitContent();
@@ -85,6 +91,7 @@ export class Viewport extends HTMLElement {
             }),
             svg({
                 icon: "icon-zoomin",
+                title: new Localize("viewport.zoomIn"),
                 onclick: () => {
                     this.view.cameraController.zoom(this.view.width / 2, this.view.height / 2, -5);
                     this.view.update();
@@ -92,6 +99,7 @@ export class Viewport extends HTMLElement {
             }),
             svg({
                 icon: "icon-zoomout",
+                title: new Localize("viewport.zoomOut"),
                 onclick: () => {
                     this.view.cameraController.zoom(this.view.width / 2, this.view.height / 2, 5);
                     this.view.update();
@@ -184,6 +192,7 @@ export class Viewport extends HTMLElement {
             },
             svg({
                 icon: icon,
+                title: new Localize(`viewport.${cameraType}`),
                 onclick: (e) => {
                     e.stopPropagation();
                     this.view.cameraController.cameraType = cameraType;


### PR DESCRIPTION
The other icons and buttons showed their name when hovered, but these buttons did not and now do. 

- Add localization keys for viewport controls (orthographic, perspective, fit content, zoom in/out)

The Chinese translation was auto generated, please verify the translation is accurate