### PR TITLE
Security: Remote plugin loading can execute arbitrary untrusted code

### DIFF
--- a/packages/web/src/index.ts
+++ b/packages/web/src/index.ts
@@ -14,8 +14,14 @@ async function handleApplicaionBuilt(app: IApplication) {
     const params = new URLSearchParams(window.location.search);
     const plugin = params.get("plugin");
     if (plugin) {
-        Logger.info(`loading plugin from: ${plugin}`);
-        await app.pluginManager.loadFromUrl(plugin);
+        const pluginUrl = new URL(plugin, window.location.href);
+        if (pluginUrl.origin !== window.location.origin || pluginUrl.protocol !== window.location.protocol) {
+            throw new Error(`Refusing to load plugin from untrusted origin: ${pluginUrl.origin}`);
+        }
+        if (window.confirm(`Load plugin from ${pluginUrl.href}?`)) {
+            Logger.info(`loading plugin from: ${pluginUrl.href}`);
+            await app.pluginManager.loadFromUrl(pluginUrl.href);
+        }
     }
     const url = params.get("url") ?? params.get("model");
     if (url) {


### PR DESCRIPTION
## Summary

Security: Remote plugin loading can execute arbitrary untrusted code

## Problem

**Severity**: `Critical` | **File**: `packages/web/src/index.ts:L12`

The web entrypoint accepts a `plugin` URL query parameter and passes it directly to `app.pluginManager.loadFromUrl(plugin)`. The plugin system supports loading JavaScript modules, CSS, and import maps from remote URLs, and plugin code is executed in the application context. This creates a straightforward remote code execution/supply-chain risk if an attacker can influence the URL or convince a user to open a crafted link.

## Solution

Restrict plugin loading to trusted origins only, require explicit user confirmation before loading remote plugins, and validate/sign plugin manifests. Consider disabling remote plugin loading by default and only allowing local files or allowlisted domains.

## Changes

- `packages/web/src/index.ts` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced